### PR TITLE
Fixed bug with blinking images in recycler view and stucking them in …

### DIFF
--- a/app/src/main/java/org/imozerov/streetartview/ui/explore/list/ArtListAdapter.kt
+++ b/app/src/main/java/org/imozerov/streetartview/ui/explore/list/ArtListAdapter.kt
@@ -20,11 +20,15 @@ class ArtListAdapter(private val context: Context, private var data: List<ArtObj
 
     override fun onBindViewHolder(holder: ArtListViewHolder, position: Int) {
         val artObject = data!![position]
+        if (holder.artObjectId != artObject.id) {
+            holder.thumb.loadImage(artObject.thumbPicUrl)
+        }
         holder.artObjectId = artObject.id
-        holder.thumb.loadImage(artObject.thumbPicUrl)
     }
 
     override fun getItemCount() = data!!.size
+
+    override fun getItemId(position: Int) = data!![position].id.hashCode().toLong()
 
     fun setData(artObjectUis: List<ArtObjectUi>) {
         data = artObjectUis

--- a/app/src/main/java/org/imozerov/streetartview/ui/explore/list/ArtListFragment.kt
+++ b/app/src/main/java/org/imozerov/streetartview/ui/explore/list/ArtListFragment.kt
@@ -35,6 +35,7 @@ class ArtListFragment : Fragment(), Filterable, ArtView {
         presenter = ArtListPresenter(this)
 
         adapter = ArtListAdapter(context, java.util.ArrayList<ArtObjectUi>())
+        adapter!!.setHasStableIds(true)
         rootView.art_objects_recycler_view.setHasFixedSize(true)
 
         val layoutManager = GridLayoutManager(context, 3)

--- a/app/src/main/java/org/imozerov/streetartview/ui/extensions/UiExtensions.kt
+++ b/app/src/main/java/org/imozerov/streetartview/ui/extensions/UiExtensions.kt
@@ -13,9 +13,6 @@ import org.imozerov.streetartview.R
 val TAG = "UiExtensions"
 
 fun ImageView.loadImage(imagePath: String) {
-    if (drawable != null) {
-        return
-    }
     if (imagePath.isNotBlank()) {
         Picasso.with(context)
                 .load(imagePath)


### PR DESCRIPTION
…the wrong position.

Added check in Adapter if the item has the same id before trying to load the image into it.
